### PR TITLE
Add "DevFest Seattle" title in UI

### DIFF
--- a/data/en/resources.json
+++ b/data/en/resources.json
@@ -1,6 +1,6 @@
 {
   "title": "GDG DevFest Seattle 2016",
-  "dates": "October 15, 2016",
+  "dates": "DevFest Seattle - October 15, 2016",
   "home": "Home",
   "blog": "Blog",
   "speakers": "Speakers",


### PR DESCRIPTION
Right now our website doesn't have any title indicating it's DevFest Seattle although we do say that in descriptions. 

Alternatively we can update "GDG DevFest Season 2016" to "GDG DevFest Seattle 2016" like GDG Silicon Valley (https://devfest2015.gdgsv.com/). Or add a separate image logo like DevFest Nantes (https://devfest.gdgnantes.com/) or DevFest Ohio (https://ohiodevfest.com/). Either way, we need to have a title to clearly indicate this is DevFest Seattle.